### PR TITLE
[9.12.r1] build-kernels: Add support for Nile/Ganges platform

### DIFF
--- a/build_shared.sh
+++ b/build_shared.sh
@@ -18,6 +18,9 @@ echo "KERNEL_TMP  : ${KERNEL_TMP}"
 for platform in $PLATFORMS; do \
 
     case $platform in
+        nile)
+            DEVICE=$NILE;
+            DTBO="false";;
         ganges)
             DEVICE=$GANGES;
             DTBO="false";;

--- a/build_shared.sh
+++ b/build_shared.sh
@@ -18,6 +18,9 @@ echo "KERNEL_TMP  : ${KERNEL_TMP}"
 for platform in $PLATFORMS; do \
 
     case $platform in
+        ganges)
+            DEVICE=$GANGES;
+            DTBO="false";;
         edo)
             DEVICE=$EDO;
             DTBO="true";;

--- a/build_shared_vars.sh
+++ b/build_shared_vars.sh
@@ -42,11 +42,11 @@ else
     ANDROID_ROOT="$ANDROID_BUILD_TOP"
 fi
 
-
+GANGES="kirin mermaid"
 EDO="pdx203 pdx206"
 LENA="pdx213"
 
-PLATFORMS="edo lena"
+PLATFORMS="ganges edo lena"
 
 # Mkdtimg tool
 MKDTIMG=$ANDROID_ROOT/out/host/linux-x86/bin/mkdtimg

--- a/build_shared_vars.sh
+++ b/build_shared_vars.sh
@@ -42,11 +42,12 @@ else
     ANDROID_ROOT="$ANDROID_BUILD_TOP"
 fi
 
+NILE="discovery pioneer voyager"
 GANGES="kirin mermaid"
 EDO="pdx203 pdx206"
 LENA="pdx213"
 
-PLATFORMS="ganges edo lena"
+PLATFORMS="nile ganges edo lena"
 
 # Mkdtimg tool
 MKDTIMG=$ANDROID_ROOT/out/host/linux-x86/bin/mkdtimg


### PR DESCRIPTION
1. Add support for Nile platform, Discovery, Pioneer and Voyager devices.
2. Add support for Ganges platform, Kirin, Mermaid devices.

Pending... Ready to merge after the kernel gets platform support.