### PR TITLE
[9.12.r1] build-kernels: Add support for Tama platform

### DIFF
--- a/build_shared.sh
+++ b/build_shared.sh
@@ -22,6 +22,9 @@ for platform in $PLATFORMS; do \
         ganges)
             DEVICE=$GANGES;
             DTBO="false";;
+        tama)
+            DEVICE=$TAMA;
+            DTBO="true";;
         edo)
             DEVICE=$EDO;
             DTBO="true";;

--- a/build_shared_vars.sh
+++ b/build_shared_vars.sh
@@ -44,10 +44,11 @@ fi
 
 NILE="discovery pioneer voyager"
 GANGES="kirin mermaid"
+TAMA="akari apollo akatsuki"
 EDO="pdx203 pdx206"
 LENA="pdx213"
 
-PLATFORMS="nile ganges edo lena"
+PLATFORMS="nile ganges tama edo lena"
 
 # Mkdtimg tool
 MKDTIMG=$ANDROID_ROOT/out/host/linux-x86/bin/mkdtimg


### PR DESCRIPTION
Add support for Tama platform Akari, Apollo and Akatsuki devices
(Xpera XZ2, Xperia XZ2 Compact and Xperia XZ3 accordingly).

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>