### PR TITLE
[9.12.r1] build-kernels: Add support for Seine platform

### DIFF
--- a/build_shared.sh
+++ b/build_shared.sh
@@ -27,6 +27,9 @@ for platform in $PLATFORMS; do \
         tama)
             DEVICE=$TAMA;
             DTBO="true";;
+        seine)
+            DEVICE=$SEINE;
+            DTBO="true";;
         edo)
             DEVICE=$EDO;
             DTBO="true";;

--- a/build_shared_vars.sh
+++ b/build_shared_vars.sh
@@ -45,10 +45,11 @@ fi
 NILE="discovery pioneer voyager"
 GANGES="kirin mermaid"
 TAMA="akari apollo akatsuki"
+SEINE="pdx201"
 EDO="pdx203 pdx206"
 LENA="pdx213"
 
-PLATFORMS="nile ganges tama edo lena"
+PLATFORMS="nile ganges tama seine edo lena"
 
 KERNEL_TOP=$ANDROID_ROOT/kernel/sony/msm-4.19
 


### PR DESCRIPTION
Add support for Seine platform PDX201 device (Xpera 10 II).

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>