### PR TITLE
[9.12.r1] build-kernels: Add support for Kumano platform

### DIFF
--- a/build_shared.sh
+++ b/build_shared.sh
@@ -27,6 +27,9 @@ for platform in $PLATFORMS; do \
         tama)
             DEVICE=$TAMA;
             DTBO="true";;
+        kumano)
+            DEVICE=$KUMANO;
+            DTBO="true";;
         seine)
             DEVICE=$SEINE;
             DTBO="true";;

--- a/build_shared_vars.sh
+++ b/build_shared_vars.sh
@@ -47,11 +47,12 @@ fi
 NILE="discovery pioneer voyager"
 GANGES="kirin mermaid"
 TAMA="akari apollo akatsuki"
+KUMANO="griffin bahamut"
 SEINE="pdx201"
 EDO="pdx203 pdx206"
 LENA="pdx213"
 
-PLATFORMS="nile ganges tama seine edo lena"
+PLATFORMS="nile ganges tama kumano seine edo lena"
 
 KERNEL_TOP=$ANDROID_ROOT/kernel/sony/msm-4.19
 


### PR DESCRIPTION
Add support for Kumano platform Griffin, and Bahamut devices
(Xpera 1 and Xperia 5 accordingly).

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>