### PR TITLE
[9.12.r1] Support compilation without obsolete GNU binutils

### DIFF
--- a/build-kernels-clang.sh
+++ b/build-kernels-clang.sh
@@ -5,6 +5,7 @@
 
 CLANG_A11=$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r353983c/bin/
 CLANG_A12=$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r416183b/bin/
+CLANG_A13=$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r450784d/bin/
 
 if [ -d "$CLANG_A11" ]; then
     echo "Using Clang (build r353983) from Android 11."
@@ -12,6 +13,9 @@ if [ -d "$CLANG_A11" ]; then
 elif  [ -d "$CLANG_A12" ]; then
     echo "Using Clang (build r416183b) from Android 12."
     export CLANG=$CLANG_A12
+elif  [ -d "$CLANG_A13" ]; then
+    echo "Using Clang (build r450784d) from Android 13."
+    export CLANG=$CLANG_A13
 fi
 
 # Cross Compiler

--- a/build-kernels-clang.sh
+++ b/build-kernels-clang.sh
@@ -22,7 +22,7 @@ fi
 CC="clang"
 
 # Build command
-BUILD_ARGS="CLANG_TRIPLE=aarch64-linux-gnu"
+BUILD_ARGS=""
 
 PATH=$CLANG:$PATH
 # source shared parts

--- a/build-kernels-clang.sh
+++ b/build-kernels-clang.sh
@@ -19,7 +19,7 @@ elif  [ -d "$CLANG_A13" ]; then
 fi
 
 # Build command
-BUILD_ARGS=""
+BUILD_ARGS="LLVM=1 LLVM_IAS=1"
 
 PATH=$CLANG:$PATH
 # source shared parts

--- a/build-kernels-clang.sh
+++ b/build-kernels-clang.sh
@@ -18,9 +18,6 @@ elif  [ -d "$CLANG_A13" ]; then
     export CLANG=$CLANG_A13
 fi
 
-# Cross Compiler
-CC="clang"
-
 # Build command
 BUILD_ARGS=""
 

--- a/build_shared.sh
+++ b/build_shared.sh
@@ -56,7 +56,7 @@ for platform in $PLATFORMS; do \
                 make O="$KERNEL_TMP" ARCH=arm64 \
                                           CROSS_COMPILE=aarch64-linux-android- \
                                           CROSS_COMPILE_ARM32=arm-linux-androideabi- \
-                                          -j$(nproc) ${BUILD_ARGS} ${CC:+CC="${CC}"} \
+                                          -j$(nproc) ${BUILD_ARGS} \
                                           aosp_${platform}_${device}_defconfig
 
                 echo "The build may take up to 10 minutes. Please be patient ..."
@@ -65,7 +65,7 @@ for platform in $PLATFORMS; do \
                 make O="$KERNEL_TMP" ARCH=arm64 \
                      CROSS_COMPILE=aarch64-linux-android- \
                      CROSS_COMPILE_ARM32=arm-linux-androideabi- \
-                     -j$(nproc) ${BUILD_ARGS} ${CC:+CC="${CC}"} \
+                     -j$(nproc) ${BUILD_ARGS} \
                      >"$KERNEL_TMP"/build.log 2>&1;
 
                 echo "Copying new kernel image ..."

--- a/build_shared_vars.sh
+++ b/build_shared_vars.sh
@@ -58,6 +58,3 @@ KERNEL_TOP=$ANDROID_ROOT/kernel/sony/msm-4.19
 
 # $KERNEL_TMP sub dir per script
 KERNEL_TMP=${build_directory:-$ANDROID_ROOT/out/${0##*-}/kernel-tmp}
-
-export PATH=$PATH:$ANDROID_ROOT/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/bin
-export PATH=$PATH:$ANDROID_ROOT/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/bin


### PR DESCRIPTION
This patch is needed to get rid of deprecated GNU binutils and compile the kernel using only Clang/LLVM dependencies.
Depends on https://github.com/sonyxperiadev/kernel/pull/2537 and should only be merged after it.

Part of the plan:
https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+/master/BINUTILS_KERNEL_DEPRECATION.md

Tested on:
|| **Android 12**  | **Android 13** |
|:-:|:-:|:-:|
| **Akari** | ✓ | ✓ |
| **Griffin** | ✓ | ✓ |
| **PDX201** | ✓ | ✓ |