### PR TITLE
[9.12.r1] Fix Android 13 Clang build and boot

### DIFF
--- a/build-kernels-clang.sh
+++ b/build-kernels-clang.sh
@@ -2,7 +2,6 @@
 
 . "${0%/*}/build_shared_vars.sh"
 
-
 CLANG_A11=$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r353983c/bin/
 CLANG_A12=$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r416183b/bin/
 CLANG_A13=$ANDROID_ROOT/prebuilts/clang/host/linux-x86/clang-r450784d/bin/

--- a/build-kernels-clang.sh
+++ b/build-kernels-clang.sh
@@ -22,7 +22,7 @@ fi
 CC="clang"
 
 # Build command
-BUILD_ARGS="CLANG_TRIPLE=aarch64-linux-gnu"
+BUILD_ARGS=""
 
 PATH=$CLANG:$PATH
 # source shared parts

--- a/build-kernels-clang.sh
+++ b/build-kernels-clang.sh
@@ -19,7 +19,7 @@ elif  [ -d "$CLANG_A13" ]; then
 fi
 
 # Build command
-BUILD_ARGS=""
+BUILD_ARGS="LLVM=1 LLVM_IAS=1"
 
 PATH=$CLANG:$PATH
 # source shared parts

--- a/build-kernels-clang.sh
+++ b/build-kernels-clang.sh
@@ -18,9 +18,6 @@ elif  [ -d "$CLANG_A13" ]; then
     export CLANG=$CLANG_A13
 fi
 
-# Cross Compiler
-CC="clang"
-
 # Build command
 BUILD_ARGS=""
 

--- a/build_shared.sh
+++ b/build_shared.sh
@@ -56,7 +56,7 @@ for platform in $PLATFORMS; do \
                 make O="$KERNEL_TMP" ARCH=arm64 \
                                           CROSS_COMPILE=aarch64-linux-android- \
                                           CROSS_COMPILE_ARM32=arm-linux-androideabi- \
-                                          -j$(nproc) ${BUILD_ARGS} ${CC:+CC="${CC}"} \
+                                          -j$(nproc) ${BUILD_ARGS} \
                                           aosp_${platform}_${device}_defconfig
 
                 echo "The build may take up to 10 minutes. Please be patient ..."
@@ -65,7 +65,7 @@ for platform in $PLATFORMS; do \
                 make O="$KERNEL_TMP" ARCH=arm64 \
                      CROSS_COMPILE=aarch64-linux-android- \
                      CROSS_COMPILE_ARM32=arm-linux-androideabi- \
-                     -j$(nproc) ${BUILD_ARGS} ${CC:+CC="${CC}"} \
+                     -j$(nproc) ${BUILD_ARGS} \
                      >"$KERNEL_TMP"/build.log 2>&1;
 
                 echo "Copying new kernel image ..."

--- a/build_shared.sh
+++ b/build_shared.sh
@@ -15,6 +15,12 @@ echo "KERNEL_TOP  : ${KERNEL_TOP}"
 echo "KERNEL_TMP  : ${KERNEL_TMP}"
 echo "MKDTIMG     : ${MKDTIMG}"
 
+BUILD_ARGS="${BUILD_ARGS} \
+ARCH=arm64 \
+CROSS_COMPILE=aarch64-linux-android- \
+CROSS_COMPILE_ARM32=arm-linux-androideabi- \
+-j$(nproc)"
+
 for platform in $PLATFORMS; do \
 
     case $platform in
@@ -46,41 +52,34 @@ for platform in $PLATFORMS; do \
             if [ ! $only_build_for ] || [ $device = $only_build_for ] ; then
 
                 # Don't override $KERNEL_TMP when set by manually
-                [ ! "$build_directory" ] && KERNEL_TMP=$KERNEL_TMP-${device}
+                [ ! "$build_directory" ] && KERNEL_TMP_DEVICE=$KERNEL_TMP/${device}
                 # Keep kernel tmp when building for a specific device or when using keep tmp
-                [ ! "$keep_kernel_tmp" ] && [ ! "$only_build_for" ] &&rm -rf "${KERNEL_TMP}"
-                mkdir -p "${KERNEL_TMP}"
+                [ ! "$keep_kernel_tmp" ] && [ ! "$only_build_for" ] &&rm -rf "${KERNEL_TMP_DEVICE}"
+                mkdir -p "${KERNEL_TMP_DEVICE}"
+
+                BUILD_ARGS_DEVICE="$BUILD_ARGS O=$KERNEL_TMP_DEVICE"
 
                 echo "================================================="
                 echo "Platform -> ${platform} :: Device -> $device"
-                make O="$KERNEL_TMP" ARCH=arm64 \
-                                          CROSS_COMPILE=aarch64-linux-android- \
-                                          CROSS_COMPILE_ARM32=arm-linux-androideabi- \
-                                          -j$(nproc) ${BUILD_ARGS} \
-                                          aosp_${platform}_${device}_defconfig
+                make $BUILD_ARGS_DEVICE aosp_${platform}_${device}_defconfig
 
                 echo "The build may take up to 10 minutes. Please be patient ..."
                 echo "Building new kernel image ..."
-                echo "Logging to $KERNEL_TMP/build.log"
-                make O="$KERNEL_TMP" ARCH=arm64 \
-                     CROSS_COMPILE=aarch64-linux-android- \
-                     CROSS_COMPILE_ARM32=arm-linux-androideabi- \
-                     -j$(nproc) ${BUILD_ARGS} \
-                     >"$KERNEL_TMP"/build.log 2>&1;
+                echo "Logging to $KERNEL_TMP_DEVICE/build.log"
+                make $BUILD_ARGS_DEVICE > "$KERNEL_TMP_DEVICE/build.log" 2>&1;
 
                 echo "Copying new kernel image ..."
-                cp "$KERNEL_TMP/arch/arm64/boot/Image.gz-dtb" "$KERNEL_TOP/common-kernel/kernel-dtb-$device"
-                if [ $DTBO = "true" ]; then
+                cp "$KERNEL_TMP_DEVICE/arch/arm64/boot/Image.gz-dtb" "$KERNEL_TOP/common-kernel/kernel-dtb-$device"
+                if [ "$DTBO" = "true" ]; then
                     # shellcheck disable=SC2046
                     # note: We want wordsplitting in this case.
-                    $MKDTIMG create "$KERNEL_TOP"/common-kernel/dtbo-${device}.img $(find "$KERNEL_TMP"/arch/arm64/boot/dts -name "*.dtbo")
+                    $MKDTIMG create "$KERNEL_TOP"/common-kernel/dtbo-${device}.img $(find "$KERNEL_TMP_DEVICE"/arch/arm64/boot/dts -name "*.dtbo")
                 fi
 
             fi
         )
     done
 done
-
 
 echo "================================================="
 echo "Done!"

--- a/build_shared.sh
+++ b/build_shared.sh
@@ -17,8 +17,8 @@ echo "MKDTIMG     : ${MKDTIMG}"
 
 BUILD_ARGS="${BUILD_ARGS} \
 ARCH=arm64 \
-CROSS_COMPILE=aarch64-linux-android- \
-CROSS_COMPILE_ARM32=arm-linux-androideabi- \
+CROSS_COMPILE=aarch64-linux-gnu- \
+CROSS_COMPILE_ARM32=arm-linux-gnueabi- \
 -j$(nproc)"
 
 for platform in $PLATFORMS; do \

--- a/build_shared_vars.sh
+++ b/build_shared_vars.sh
@@ -57,4 +57,5 @@ PLATFORMS="nile ganges tama kumano seine edo lena"
 KERNEL_TOP=$ANDROID_ROOT/kernel/sony/msm-4.19
 
 # $KERNEL_TMP sub dir per script
-KERNEL_TMP=${build_directory:-$ANDROID_ROOT/out/${0##*-}/kernel-tmp}
+c=${0##*-}
+KERNEL_TMP=${build_directory:-$ANDROID_ROOT/out/kernel-4.19/${c%%.sh}}

--- a/build_shared_vars.sh
+++ b/build_shared_vars.sh
@@ -58,6 +58,3 @@ KERNEL_TOP=$ANDROID_ROOT/kernel/sony/msm-4.19
 
 # $KERNEL_TMP sub dir per script
 KERNEL_TMP=${build_directory:-$ANDROID_ROOT/out/${0##*-}/kernel-tmp}
-
-export PATH=$PATH:$ANDROID_ROOT/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/bin
-export PATH=$PATH:$ANDROID_ROOT/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/bin


### PR DESCRIPTION
Reapply https://github.com/sonyxperiadev/kernel-sony-msm-4.19-common/pull/9.
Now all devices can be successfully booted using Clang provided with Android 13.

Tested on Tama Akatsuki, and Seine PDX201.